### PR TITLE
Tiny string check fix

### DIFF
--- a/src/org/powerbot/script/rt4/World.java
+++ b/src/org/powerbot/script/rt4/World.java
@@ -47,7 +47,7 @@ public class World extends ClientAccessor
 				return Specialty.PVP;
 			if(str.contains("Deadman"))
 				return Specialty.DEAD_MAN;
-			if(str.contains("skill total"))
+			if(str.contains("skill t"))
 				return Specialty.SKILL_REQUIREMENT;
 			if(!str.contains("-"))
 				return Specialty.MINI_GAME;


### PR DESCRIPTION
This check wouldn't work for 2000 total skill level+ because the text for the component comes out as 2000 skill t not 2000 skill total
